### PR TITLE
Remove quotes around "no budget"

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -2,21 +2,21 @@
 <html>
   <head>
     <title>Who Pays Conference Speakers?</title>
-    <meta name="description" content="Speaking at a tech conference can be costly. Discussions about money are sometimes taboo because we often pretend that passion and exposure should pay the way. While some conferences have 'no budget', many offer to cover travel and accommodations or pay honorarium.">
+    <meta name="description" content="Speaking at a tech conference can be costly. Discussions about money are sometimes taboo because we often pretend that passion and exposure should pay the way. While some conferences have no budget, many offer to cover travel and accommodations or pay honorarium.">
 
     <meta property="og:title" content="Who Pays Conference Speakers?">
     <meta property="og:image" content="http://whopays.techspeakers.info/img/media.jpg"/>
-    <meta property="og:description" content="Speaking at a tech conference can be costly. Discussions about money are sometimes taboo because we often pretend that passion and exposure should pay the way. While some conferences have 'no budget', many offer to cover travel and accommodations or pay honorarium.">
+    <meta property="og:description" content="Speaking at a tech conference can be costly. Discussions about money are sometimes taboo because we often pretend that passion and exposure should pay the way. While some conferences have no budget, many offer to cover travel and accommodations or pay honorarium.">
 
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@WhoPaysSpeakers">
     <meta name="twitter:creator" content="@kosamari">
     <meta name="twitter:title" content="Who Pays Conference Speakers?">
-    <meta name="twitter:description" content="Speaking at a tech conference can be costly. Discussions about money are sometimes taboo because we often pretend that passion and exposure should pay the way. While some conferences have 'no budget', many offer to cover travel and accommodations or pay honorarium.">
+    <meta name="twitter:description" content="Speaking at a tech conference can be costly. Discussions about money are sometimes taboo because we often pretend that passion and exposure should pay the way. While some conferences have no budget, many offer to cover travel and accommodations or pay honorarium.">
     <meta name="twitter:image:src" content="http://whopays.techspeakers.info/img/media.jpg">
 
     <meta itemprop="name" content="Who Pays Conference Speakers?">
-    <meta itemprop="description" content="Speaking at a tech conference can be costly. Discussions about money are sometimes taboo because we often pretend that passion and exposure should pay the way. While some conferences have 'no budget', many offer to cover travel and accommodations or pay honorarium.">
+    <meta itemprop="description" content="Speaking at a tech conference can be costly. Discussions about money are sometimes taboo because we often pretend that passion and exposure should pay the way. While some conferences have no budget, many offer to cover travel and accommodations or pay honorarium.">
     <meta itemprop="image" content="http://whopays.techspeakers.info/img/media.jpg">
 
     <link href="//fonts.googleapis.com/css?family=Open+Sans:300italic,300,400italic,400,600italic,600,700italic,700,800italic,800" rel="stylesheet" type="text/css">
@@ -35,7 +35,7 @@
       </header>
       <section>
         <h3 class="center">Speaking at a tech conference can be costly.</h3>
-        <p>We (speakers) love giving talks at technical conferences, but discussions about money are sometimes taboo because we often pretend that passion and exposure should pay the way. While some conferences have "no budget", many offer to cover travel & accommodations or pay honorarium.</p>
+        <p>We (speakers) love giving talks at technical conferences, but discussions about money are sometimes taboo because we often pretend that passion and exposure should pay the way. While some conferences have no budget, many offer to cover travel & accommodations or pay honorarium.</p>
         <p>
         Let’s help each other by sorting through some of the confusion, and develop an ongoing dialog about the cost of public speaking.</p>
         <p align="right"><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://whopays.techspeakers.info/" data-text="Who pays conference speakers?" data-dnt="true">Tweet</a>


### PR DESCRIPTION
Quotation marks can imply sarcasm about the quoted content, which isn't
our intention. We want to open a dialog without initial bias.

Many conferences are legitimately unable to pay speakers' travel costs
or to offer honorarium. The budgetary concerns faced by organizers,
especially of conferences in their first or second year, are big and
scary. The first year, organizers likely have no idea what they're doing
and the large costs associated with a conference are intimidating.

It is not uncommon for the costs of the event to outweigh the revenue
generated by tickets and sponsors. It's very easy to underestimate the
costs when pricing tickets and to not be able to attract enough sponsor
money to make up the difference.

In a conference's second year, organizers are faced by the chance that
the positive feedback they received for their ostensibly successful
first year was disingenuous. This can lead to not selling enough tickets
and an even harder time attracting sponsors (as well as speakers).

We understand that these concerns are a mitigating factor in offering to
pay the way of speakers.
