### PR TITLE
Adding links to clarify intent of 1st paragraph

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -35,7 +35,7 @@
       </header>
       <section>
         <h3 class="center">Speaking at a tech conference can be costly.</h3>
-        <p>We (speakers) love giving talks at technical conferences, but discussions about money are sometimes taboo because we often pretend that passion and exposure should pay the way. While some conferences have "no budget", many offer to cover travel & accommodations or pay honorarium.</p>
+        <p>We (speakers) love giving talks at technical conferences, but discussions about money are sometimes taboo because we often pretend that passion and exposure should pay the way. While some conferences have <a href="https://remysharp.com/2014/03/07/youre-paying-to-speak">"no budget"</a>, many offer to cover <a href="http://cfp.jsconf.co/events/speaker">travel & accommodations</a> or <a href="https://twitter.com/ashedryden/status/564899600335925248"> pay honorarium</a>.</p>
         <p>
         Let’s help each other by sorting through some of the confusion, and develop an ongoing dialog about the cost of public speaking.</p>
         <p align="right"><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://whopays.techspeakers.info/" data-text="Who pays conference speakers?" data-dnt="true">Tweet</a>


### PR DESCRIPTION
Based on discussion at PR #6 
I am adding link to resources on statement I make at 1st paragraph.
- "no budget" link to [You're paying to speak](https://remysharp.com/2014/03/07/youre-paying-to-speak) from @remy
-  travel & accommodations link to [What do Speakers get?](http://cfp.jsconf.co/events/speaker) from JSConf Colombia
- pay honorarium link to [a tweet about AlterConf](https://twitter.com/ashedryden/status/564899600335925248) from @ashedryden
