### PR TITLE
Fix event type grammar (missing "a")

### DIFF
--- a/report.js
+++ b/report.js
@@ -181,7 +181,7 @@ function aboutSpeaker(gender, speakingYears, unit){
 }
 function aboutEvent(type){
   if(type){
-    return "This was "+type+' event.';
+    return "This was a "+type+' event.';
   }
   return '';
 }


### PR DESCRIPTION
Might should be "an"? But definitely needs _something_ there, I'm pretty sure it's "a" :)

It now reads:
- This was **a** not for profit event.
- This was **a** for profit event.
