### PR TITLE
Button to scroll directly to reports

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -53,6 +53,27 @@ footer > p{
   text-align: center;
 }
 
+.experience-bttn-container {
+  text-align: center;
+}
+
+.experience-bttn {
+  background-color: blue;
+  border: none;
+  border-radius: 4px;
+  color: white;
+  cursor: pointer;
+  font-size: 20px;
+  padding: 0.5em 1em;
+  opacity: 0.7;
+  outline: none;
+  transition: all .2s linear;
+}
+
+.experience-bttn:hover {
+  opacity: 1;
+}
+
 /*
 Form Styling
 */

--- a/views/index.html
+++ b/views/index.html
@@ -38,8 +38,10 @@
       <section>
         <h3 class="center">Speaking at a tech conference can be costly.</h3>
         <p>We (speakers) love giving talks at technical conferences, but discussions about money are sometimes taboo because we often pretend that passion and exposure should pay the way. While some conferences have <a href="https://remysharp.com/2014/03/07/youre-paying-to-speak">"no budget"</a>, many offer to cover <a href="http://cfp.jsconf.co/events/speaker">travel & accommodations</a> or <a href="https://twitter.com/ashedryden/status/564899600335925248"> pay honorarium</a>.</p>
-        <p>
-        Let’s help each other by sorting through some of the confusion, and develop an ongoing dialog about the cost of public speaking.</p>
+        <p>Let’s help each other by sorting through some of the confusion, and develop an ongoing dialog about the cost of public speaking.</p>
+        <div class="experience-bttn-container">
+            <button class="experience-bttn">Learn from the experience of others</button>
+        </div>
         <p align="right"><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://whopays.techspeakers.info/" data-text="Who pays conference speakers?" data-dnt="true">Tweet</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></p>
       </section>
@@ -278,6 +280,15 @@
       $('#more').remove();
     }
 
+    function scrollToTarget(target) {
+        var offset = Math.floor($(target).position().top) + 'px';
+        return function scrollFn() {
+          $('body, html').animate({
+            scrollTop: offset
+          });
+        }
+    }
+
     function setupAutoComplete(){
       ['event_name', 'event_location'].forEach(function(x) {
         $('#'+x).autocomplete({
@@ -301,6 +312,10 @@
       });
     });
 
+    $(document).ready(function documentLoaded(){
+      var scrollToReport = scrollToTarget('#report');
+      $('.experience-bttn').click(scrollToReport);
+    });
     </script>
     {{#if ga}}
       {{> ga }}


### PR DESCRIPTION
This PR is for issue kosamari/who-pays-tech-speakers#30

I went with the heading from the reports section ("Learn from the experience of others") because I thought it was a clearer than "Read Reports" but I can change it back if you prefer. 
